### PR TITLE
Migrate to the new container architecture.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: c
 
+sudo: false
+
 env:
   matrix:
     - CONDA_PY=2.7

--- a/devtools/ci/install.sh
+++ b/devtools/ci/install.sh
@@ -11,9 +11,6 @@ PIP_ARGS="-U"
 
 export PATH=$HOME/miniconda/bin:$PATH
 
-sudo apt-get update
-#sudo apt-get install -qq -y g++ gfortran csh g++-multilib gcc-multilib openbabel
-
 conda update --yes conda
 conda config --add channels http://conda.binstar.org/omnia
 conda install --yes conda-build jinja2 binstar pip


### PR DESCRIPTION
I did this for ParmEd awhile back, and @rmcgibbo then did it for MDTraj.  They suggest doing this, and it *does* cut build times roughly in half (*and* builds start in seconds now).

I think that under the hood, the difference between the new container and legacy architectures in Travis is roughly (exactly?) the difference between Docker and Vagrant, respectively.