### PR TITLE
Use openmm >=6.3.0 in pdbfixer-dev package, not openmm-dev

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -10,12 +10,12 @@ requirements:
   build:
     - python
     - setuptools
-    - openmm-dev
+    - openmm >=6.3.0
     - numpy
 
   run:
     - python
-    - openmm-dev
+    - openmm >=6.3.0
     - numpy
 
 test:


### PR DESCRIPTION
We had previously been using `openmm-dev` for the `pdbfixer-dev` conda package.  Now we use `openmm >=6.3.0`.