### PR TITLE
Fix BINSTAR_TOKEN so pdbfixer-dev upload works correctly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
     - ORGNAME="omnia" # the name of the organization
     - PACKAGENAME="pdbfixer" # the name of your package
     # encrypted BINSTAR_TOKEN for push of dev package to binstar
-    - secure: "T7qEO3BVXdEP3J4bqE8X882KrdGD4L0cwbAjX/SZMm8e8bG/qmv7XWkxIDp/HakR5GlGr3EBGQDJi5g2CbmFwHjxXMbZ4Y0a3dvoCvfdBNUpBZcjPSil2X976aEkTR1MAL8X7VjuY4lwogqO2WU7Kzm1QaFWjWEl1fV/zxHYN9w="
+    - secure: "hhzbVwxc6bUUkvcU4SauCUSGUIwDHV5Mq7lNZkzhQOeOQOXBCoew3zl44qwLUUYbO+Hla/+U2UqxvXZ5vx4IJzvHcMJhXB6ZiNwc5hwZtvduWzmDJZ+ErASDsdvRCGXxDz90TkOxoL/Wy6lMr6OIMMosrjY6NJGotMiCB9IUDqY="
 
 after_success:
   - echo "after_success"

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: pdbfixer-dev
-  version: dev
+  version: 0.0.0
 
 build:
   entry_points:

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -3,7 +3,7 @@ pushd .
 cd $HOME
 
 # Install Miniconda
-MINICONDA=Miniconda-latest-Linux-x86_64.sh
+MINICONDA=Miniconda2-latest-Linux-x86_64.sh
 MINICONDA_HOME=$HOME/miniconda
 MINICONDA_MD5=$(curl -s http://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
 wget -q http://repo.continuum.io/miniconda/$MINICONDA


### PR DESCRIPTION
Fixes #127.

Note that this will require merging to work since the secure environment variables aren't substituted in PRs.