### PR TITLE
Remove heterogens before finding missing atoms

### DIFF
--- a/Manual.html
+++ b/Manual.html
@@ -56,6 +56,8 @@ On this page you select the PDB file to process.  You can load a file from your 
 <h3>Select Chains</h3>
 
 This is the first place where you can choose to remove parts of the structure.  It lists all chains contained in the file.  If you want to remove some of them, just uncheck them before clicking "Continue".
+<p>
+This page also gives options for removing heterogens.  A heterogen is any residue other than a standard amino acid or nucleotide.  The possible options are to keep all heterogens; keep only water while deleting all other heterogens; or delete all heterogens.
 
 <h3>Add Residues</h3>
 
@@ -69,12 +71,11 @@ If the file contains nonstandard residues, this page will allow you to replace t
 
 This page lists all heavy atoms that are missing from the file.  They will be added automatically.
 
-<h3>Remove Heterogens/Add Hydrogens/Add Water</h3>
+<h3>Add Hydrogens and Water</h3>
 
-This page gives you the chance to make several other optional changes:
+This page gives you the chance to make other optional changes:
 
 <ul>
-    <li><b>Remove Heterogens</b> A heterogen is any residue other than a standard amino acid or nucleotide.  PDBFixer can automatically remove them for you.  The possible options are to keep all heterogens; keep only water while deleting all other heterogens; or delete all heterogens.</li>
     <li><b>Add Missing Hydrogens</b> If hydrogen atoms are missing from the file, PDBFixer can add them for you.  Some residues can exist in multiple protonation states.  To select which one to use, you can specify a pH, and the most common form of each residue at that pH will be used.</li>
     <li><b>Add Water</b> Add a water box surrounding the system.  In addition to water, counterions will be added to neutalize the system.  You also may choose to add more ions based on a desired total ionic strength.  Select the ionic strength and the types of ions to use.
 </ul>
@@ -174,6 +175,14 @@ fixer.replaceNonstandardResidues()
 </pre></tt>
 <tt>findNonstandardResidues()</tt> stores the results into the <tt>nonstandardResidues</tt> field, which is a list.  Each entry is a tuple whose first element is a <tt>Residue</tt> object and whose second element is the name of the suggested replacement residue.  Before calling <tt>replaceNonstandardResidues()</tt> you can modify the contents of this list.  For example, you can remove an entry to prevent a particular residue from being replaced, or you can change what it will be replaced with.  You can even add new entries if you want to mutate other residues.
 
+<h3>Remove Heterogens</h3>
+
+If you want to remove heterogens, call
+<p>
+<tt>fixer.removeHeterogens(False)</tt>
+<p>
+The argument specifies whether to keep water molecules.  <tt>False</tt> removes all heterogens including water.  <tt>True</tt> keeps water molecules while removing all other heterogens.
+
 <h3>Add Missing Heavy Atoms</h3>
 
 To add missing heavy atoms, call
@@ -184,14 +193,6 @@ fixer.addMissingAtoms()
 <tt>findMissingAtoms()</tt> identifies all missing heavy atoms and stores them into two fields called <tt>missingAtoms</tt> and <tt>missingTerminals</tt>.  Each of these is a dictionary whose keys are <tt>Residue</tt> objects and whose values are lists of atom names.  <tt>missingAtoms</tt> contains standard atoms that should be present in any residue of that type, while <tt>missingTerminals</tt> contains missing terminal atoms that should be present at the start or end of a chain.  You are free to remove atoms from these dictionaries before continuing, if you want to prevent certain atoms from being added.
 <p>
 <tt>addMissingAtoms()</tt> is the point at which all heavy atoms get added.  This includes the ones identified by <tt>findMissingAtoms()</tt> as well as the missing residues identified by <tt>findMissingResidues()</tt>.  Also, if you used <tt>replaceNonstandardResidues()</tt> to modify any residues, that will have removed any atoms that do not belong in the replacement residue, but it will <i>not</i> have added ones that are missing from the original residue.  <tt>addMissingAtoms()</tt> is the point when those get added.
-
-<h3>Remove Heterogens</h3>
-
-If you want to remove heterogens, call
-<p>
-<tt>fixer.removeHeterogens(False)</tt>
-<p>
-The argument specifies whether to keep water molecules.  <tt>False</tt> removes all heterogens including water.  <tt>True</tt> keeps water molecules while removing all other heterogens.
 
 <h3>Add Missing Hydrogens</h3>
 
@@ -221,9 +222,9 @@ fixer = PDBFixer(filename='myfile.pdb')
 fixer.findMissingResidues()
 fixer.findNonstandardResidues()
 fixer.replaceNonstandardResidues()
+fixer.removeHeterogens(True)
 fixer.findMissingAtoms()
 fixer.addMissingAtoms()
-fixer.removeHeterogens(True)
 fixer.addMissingHydrogens(7.0)
 fixer.addSolvent(fixer.topology.getUnitCellDimensions())
 PDBFile.writeFile(fixer.topology, fixer.positions, open('output.pdb', 'w'))

--- a/pdbfixer/html/addHydrogens.html
+++ b/pdbfixer/html/addHydrogens.html
@@ -86,14 +86,6 @@ a.tooltip:hover:before {
 }
 </style>
 <form id="mainform" method="post" action="/">
-<h1>Delete Heterogens</h1>
-A heterogen is any residue other than a standard amino acid or nucleotide.  Do you want to delete heterogens?
-<p>
-<select name="heterogens">
-    <option value="all" selected>Keep all heterogens</option>
-    <option value="water">Delete heterogens except water</option>
-    <option value="none">Delete all heterogens</option>
-</select>
 <h1>Add Missing Hydrogens</h1>
 Add missing hydrogen atoms?
 <p>

--- a/pdbfixer/html/removeChains.html
+++ b/pdbfixer/html/removeChains.html
@@ -7,6 +7,14 @@ This PDB file contains %d chains.  Select which ones to include.
 </table>
 <input type="button" value="Select All" onclick="setCheckboxes(true);"/><input type="button" value="Select None" onclick="setCheckboxes(false);"/>
 <p>
+A heterogen is any residue other than a standard amino acid or nucleotide.  Do you want to delete heterogens?
+<p>
+<select name="heterogens">
+    <option value="all" selected>Keep all heterogens</option>
+    <option value="water">Delete heterogens except water</option>
+    <option value="none">Delete all heterogens</option>
+</select>
+<p>
 <input type="button" value="Continue" onclick="submitWithSpinner()"/>
 </form>
 <script>

--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -1193,6 +1193,10 @@ def main():
             fixer.findNonstandardResidues()
             if options.verbose: print('Replacing nonstandard residues...')
             fixer.replaceNonstandardResidues()
+        if options.heterogens == 'none':
+            fixer.removeHeterogens(False)
+        elif options.heterogens == 'water':
+            fixer.removeHeterogens(True)
         if options.verbose: print('Finding missing atoms...')
         fixer.findMissingAtoms()
         if options.atoms not in ('all', 'heavy'):
@@ -1200,10 +1204,6 @@ def main():
             fixer.missingTerminals = {}
         if options.verbose: print('Adding missing atoms...')
         fixer.addMissingAtoms()
-        if options.heterogens == 'none':
-            fixer.removeHeterogens(False)
-        elif options.heterogens == 'water':
-            fixer.removeHeterogens(True)
         if options.atoms in ('all', 'hydrogen'):
             if options.verbose: print('Adding missing hydrogens...')
             fixer.addMissingHydrogens(options.ph)

--- a/pdbfixer/tests/test_build_and_simulate.py
+++ b/pdbfixer/tests/test_build_and_simulate.py
@@ -137,12 +137,12 @@ def test_build_and_simulate():
             fixer.findNonstandardResidues()
             stage = "Replacing nonstandard residues..."
             fixer.replaceNonstandardResidues()
+            stage = "Removing heterogens..."
+            fixer.removeHeterogens(False)
             stage = "Finding missing atoms..."
             fixer.findMissingAtoms()
             stage = "Adding missing atoms..."
             fixer.addMissingAtoms()
-            stage = "Removing heterogens..."
-            fixer.removeHeterogens(False)
             stage = "Adding missing hydrogens..."
             fixer.addMissingHydrogens(pH)
             stage = "Writing PDB file..."

--- a/pdbfixer/ui.py
+++ b/pdbfixer/ui.py
@@ -79,6 +79,8 @@ def startPageCallback(parameters, handler):
         displayDeleteChainsPage()
 
 def deleteChainsPageCallback(parameters, handler):
+    global heterogens
+    heterogens = parameters.getfirst('heterogens')
     numChains = len(list(fixer.topology.chains()))
     deleteIndices = [i for i in range(numChains) if 'include'+str(i) not in parameters]
     fixer.removeChains(deleteIndices)
@@ -103,11 +105,6 @@ def missingAtomsPageCallback(parameters, handler):
     displayAddHydrogensPage()
 
 def addHydrogensPageCallback(parameters, handler):
-    heterogens = parameters.getfirst('heterogens')
-    if heterogens == 'none':
-        fixer.removeHeterogens(False)
-    elif heterogens == 'water':
-        fixer.removeHeterogens(True)
     if 'addhydrogens' in parameters:
         pH = float(parameters.getfirst('ph'))
         fixer.addMissingHydrogens(pH)
@@ -214,6 +211,10 @@ def displayConvertResiduesPage():
 
 def displayMissingAtomsPage():
     uiserver.setCallback(missingAtomsPageCallback)
+    if heterogens == 'none':
+        fixer.removeHeterogens(False)
+    elif heterogens == 'water':
+        fixer.removeHeterogens(True)
     fixer.findMissingAtoms()
     allResidues = list(set(fixer.missingAtoms.keys()).union(fixer.missingTerminals.keys()))
     allResidues.sort(key=lambda x: x.index)


### PR DESCRIPTION
Fixes #151.

When using the Python API, the documentation now says to call `removeHeterogens()` before `findMissingAtoms()`.  Aside from fixing this one problem, it doesn't actually matter which order you call them in, so existing scripts will continue to work as well as they did before.  But you really should reorder the calls in your scripts to avoid this problem.