### PR TITLE
Fixed error when calling _matchResidue(). OpenMM now uses compiled functions

### DIFF
--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -35,11 +35,19 @@ __version__ = "1.5"
 import simtk.openmm as mm
 import simtk.openmm.app as app
 import simtk.unit as unit
-from simtk.openmm.app.internal import compiled
 from simtk.openmm.app.internal.pdbstructure import PdbStructure
 from simtk.openmm.app.internal.pdbx.reader.PdbxReader import PdbxReader
 from simtk.openmm.app.element import hydrogen, oxygen
 from simtk.openmm.app.forcefield import NonbondedGenerator
+
+# Support Cythonized functions in OpenMM 7.3
+# and also implementations in older versions.
+try:
+    from simtk.openmm.app.internal import compiled
+    matchResidue = compiled.matchResidueToTemplate
+except ImportError:
+    matchResidue = app.forcefield._matchResidue
+
 import numpy as np
 import numpy.linalg as lin
 import sys
@@ -1132,7 +1140,7 @@ class PDBFixer(object):
 
             signature = app.forcefield._createResidueSignature([atom.element for atom in residue.atoms()])
             if signature in forcefield._templateSignatures:
-                if any(compiled.matchResidueToTemplate(residue, t, bondedToAtom, False) is not None for t in forcefield._templateSignatures[signature]):
+                if any(matchResidue(residue, t, bondedToAtom) is not None for t in forcefield._templateSignatures[signature]):
                     continue
 
             # Create a new template.

--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -35,6 +35,7 @@ __version__ = "1.5"
 import simtk.openmm as mm
 import simtk.openmm.app as app
 import simtk.unit as unit
+from simtk.openmm.app.internal import compiled
 from simtk.openmm.app.internal.pdbstructure import PdbStructure
 from simtk.openmm.app.internal.pdbx.reader.PdbxReader import PdbxReader
 from simtk.openmm.app.element import hydrogen, oxygen
@@ -1131,7 +1132,7 @@ class PDBFixer(object):
 
             signature = app.forcefield._createResidueSignature([atom.element for atom in residue.atoms()])
             if signature in forcefield._templateSignatures:
-                if any(app.forcefield._matchResidue(residue, t, bondedToAtom) is not None for t in forcefield._templateSignatures[signature]):
+                if any(compiled.matchResidueToTemplate(residue, t, bondedToAtom, False) is not None for t in forcefield._templateSignatures[signature]):
                     continue
 
             # Create a new template.


### PR DESCRIPTION
Using some functions of pdbfixer (e.g. addMissingAtoms()) with the development version of OpenMM will result in errors because of the new Cythonized functions (e.g. _matchResidue()):

```
Traceback (most recent call last):
  File "generate_states.py", line 31, in <module>
    fixer.addMissingAtoms()
  File "C:\Users\joaor\Miniconda3\lib\site-packages\pdbfixer-1.5-py3.7.egg\pdbfixer\pdbfixer.py", line 910, in addMissingAtoms
    forcefield = self._createForceField(newTopology, False)
  File "C:\Users\joaor\Miniconda3\lib\site-packages\pdbfixer-1.5-py3.7.egg\pdbfixer\pdbfixer.py", line 1135, in _createForceField
    if any(app.forcefield._matchResidue(residue, t, bondedToAtom) is not None for t in forcefield._templateSignatures[signature]):
  File "C:\Users\joaor\Miniconda3\lib\site-packages\pdbfixer-1.5-py3.7.egg\pdbfixer\pdbfixer.py", line 1135, in <genexpr>
    if any(app.forcefield._matchResidue(residue, t, bondedToAtom) is not None for t in forcefield._templateSignatures[signature]):
AttributeError: module 'simtk.openmm.app.forcefield' has no attribute '_matchResidue'
```

I modified the `pdbfixer.py` script to use the new functions (based on forcefield.py in OpenMM) and it seems to work now. I understand this creates a rift between people using OpenMM 7.2 and those that are using the development version but I thought this should be out here.