### PR TITLE
Improved handling of insertion codes

### DIFF
--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -599,12 +599,17 @@ class PDBFixer(object):
         # Find the sequence of each chain, with gaps for missing residues.
 
         for chain in chains:
-            minResidue = min(int(r.id) for r in chain.residues())
-            maxResidue = max(int(r.id) for r in chain.residues())
-            residues = [None]*(maxResidue-minResidue+1)
-            for r in chain.residues():
-                residues[int(r.id)-minResidue] = r.name
-            chainWithGaps[chain] = residues
+            residues = list(chain.residues())
+            ids = [int(r.id) for r in residues]
+            for i, res in enumerate(residues):
+                if res.insertionCode not in ('', ' '):
+                    for j in range(i, len(residues)):
+                        ids[j] += 1
+            minResidue = min(ids)
+            maxResidue = max(ids)
+            chainWithGaps[chain] = [None]*(maxResidue-minResidue+1)
+            for r, id in zip(residues, ids):
+                chainWithGaps[chain][id-minResidue] = r.name
 
         # Try to find the chain that matches each sequence.
 


### PR DESCRIPTION
This fixes the issue described in https://github.com/pandegroup/pdbfixer/issues/170#issuecomment-511239668.  It now handles that file correctly.

I was hoping this would also fix #154, but that file contains additional issues that pretty much make it impossible to correctly identify the missing residues without reading the REMARK sections.  For example, chain L skips directly from residue 94 to 96, but does not consider there to be a missing residue in between them.